### PR TITLE
[MRG] Backport forests from skopt.learning

### DIFF
--- a/skgarden/__init__.py
+++ b/skgarden/__init__.py
@@ -1,3 +1,6 @@
+from .forest import RandomForestRegressor
+from .forest import ExtraTreesRegressor
+from .gbrt import GradientBoostingQuantileRegressor
 from .mondrian import MondrianForestRegressor
 from .mondrian import MondrianTreeRegressor
 from .quantile import DecisionTreeQuantileRegressor
@@ -6,6 +9,9 @@ from .quantile import ExtraTreesQuantileRegressor
 from .quantile import RandomForestQuantileRegressor
 
 __all__ = [
+    "RandomForestRegressor",
+    "ExtraTreesRegressor",
+    "GradientBoostingQuantileRegressor",
     "MondrianTreeRegressor",
     "MondrianForestRegressor",
     "DecisionTreeQuantileRegressor",

--- a/skgarden/forest.py
+++ b/skgarden/forest.py
@@ -1,0 +1,164 @@
+import numpy as np
+from sklearn.ensemble import RandomForestRegressor as sk_RandomForestRegressor
+from sklearn.ensemble import ExtraTreesRegressor as sk_ExtraTreesRegressor
+
+
+def _return_std(X, trees, predictions, min_variance):
+    """
+    Returns `std(Y | X)`.
+
+    Can be calculated by E[Var(Y | Tree)] + Var(E[Y | Tree]) where
+    P(Tree) is `1 / len(trees)`.
+
+    Parameters
+    ----------
+    * `X` [array-like, shape=(n_samples, n_features)]:
+        Input data.
+
+    * `trees` [list, shape=(n_estimators,)]:
+        List of fit sklearn trees as obtained from the ``estimators_``
+        attribute of a fit RandomForestRegressor or ExtraTreesRegressor.
+
+    * `predictions` [array-like, shape=(n_samples,)]:
+        Prediction of each data point as returned by RandomForestRegressor
+        or ExtraTreesRegressor.
+
+    Returns
+    -------
+    * `std` [array-like, shape=(n_samples,)]:
+        Standard deviation of `y` at `X`. If criterion
+        is set to "mse", then `std[i] ~= std(y | X[i])`.
+    """
+    # This derives std(y | x) as described in 4.3.2 of arXiv:1211.0906
+    std = np.zeros(len(X))
+
+    for tree in trees:
+        var_tree = tree.tree_.impurity[tree.apply(X)]
+
+        # This rounding off is done in accordance with the
+        # adjustment done in section 4.3.3
+        # of http://arxiv.org/pdf/1211.0906v2.pdf to account
+        # for cases such as leaves with 1 sample in which there
+        # is zero variance.
+        var_tree[var_tree < min_variance] = min_variance
+        mean_tree = tree.predict(X)
+        std += var_tree + mean_tree ** 2
+
+    std /= len(trees)
+    std -= predictions ** 2.0
+    std[std < 0.0] = 0.0
+    std = std ** 0.5
+    return std
+
+
+class RandomForestRegressor(sk_RandomForestRegressor):
+    """
+    RandomForestRegressor that supports `return_std`.
+    """
+    def __init__(self, n_estimators=10, criterion='mse', max_depth=None,
+                 min_samples_split=2, min_samples_leaf=1,
+                 min_weight_fraction_leaf=0.0, max_features='auto',
+                 max_leaf_nodes=None, bootstrap=True, oob_score=False,
+                 n_jobs=1, random_state=None, verbose=0, warm_start=False,
+                 min_variance=0.0):
+        self.min_variance = min_variance
+        super(RandomForestRegressor, self).__init__(
+            n_estimators=n_estimators, criterion=criterion,
+            max_depth=max_depth,
+            min_samples_split=min_samples_split,
+            min_samples_leaf=min_samples_leaf,
+            min_weight_fraction_leaf=min_weight_fraction_leaf,
+            max_features=max_features, max_leaf_nodes=max_leaf_nodes,
+            bootstrap=bootstrap, oob_score=oob_score,
+            n_jobs=n_jobs, random_state=random_state,
+            verbose=verbose, warm_start=warm_start)
+
+    def predict(self, X, return_std=False):
+        """
+        Predict continuous output for X.
+
+        Parameters
+        ----------
+        * `X` [array-like, shape=(n_samples, n_features)]:
+            Input data.
+
+        * `return_std` [bool, default False]:
+            Whether or not to return the standard deviation.
+
+        Returns
+        -------
+        * `predictions` [array-like, shape=(n_samples,)]:
+            Predicted values for X. If criterion is set to "mse",
+            then `predictions[i] ~= mean(y | X[i])`.
+
+        * `std` [array-like, shape=(n_samples,)]:
+            Standard deviation of `y` at `X`. If criterion
+            is set to "mse", then `std[i] ~= std(y | X[i])`.
+        """
+        mean = super(RandomForestRegressor, self).predict(X)
+
+        if return_std:
+            if self.criterion != "mse":
+                raise ValueError(
+                    "Expected impurity to be 'mse', got %s instead"
+                    % self.criterion)
+            std = _return_std(X, self.estimators_, mean, self.min_variance)
+            return mean, std
+        return mean
+
+
+class ExtraTreesRegressor(sk_ExtraTreesRegressor):
+    """
+    ExtraTreesRegressor that supports `return_std`.
+    """
+    def __init__(self, n_estimators=10, criterion='mse', max_depth=None,
+                 min_samples_split=2, min_samples_leaf=1,
+                 min_weight_fraction_leaf=0.0, max_features='auto',
+                 max_leaf_nodes=None, bootstrap=False, oob_score=False,
+                 n_jobs=1, random_state=None, verbose=0, warm_start=False,
+                 min_variance=0.0):
+        self.min_variance = min_variance
+        super(ExtraTreesRegressor, self).__init__(
+            n_estimators=n_estimators, criterion=criterion,
+            max_depth=max_depth,
+            min_samples_split=min_samples_split,
+            min_samples_leaf=min_samples_leaf,
+            min_weight_fraction_leaf=min_weight_fraction_leaf,
+            max_features=max_features, max_leaf_nodes=max_leaf_nodes,
+            bootstrap=bootstrap, oob_score=oob_score,
+            n_jobs=n_jobs, random_state=random_state,
+            verbose=verbose, warm_start=warm_start)
+
+    def predict(self, X, return_std=False):
+        """
+        Predict continuous output for X.
+
+        Parameters
+        ----------
+        * `X` [array-like, shape=(n_samples, n_features)]:
+            Input data.
+
+        * `return_std` [bool, default: False]:
+            Whether or not to return the standard deviation.
+
+        Returns
+        -------
+        * `predictions` [array-like, shape=(n_samples,)]:
+            Predicted values for X. If criterion is set to "mse",
+            then `predictions[i] ~= mean(y | X[i])`.
+
+        * `std` [array-like, shape=(n_samples,)]:
+            Standard deviation of `y` at `X`. If criterion
+            is set to "mse", then `std[i] ~= std(y | X[i])`.
+        """
+        mean = super(ExtraTreesRegressor, self).predict(X)
+
+        if return_std:
+            if self.criterion != "mse":
+                raise ValueError(
+                    "Expected impurity to be 'mse', got %s instead"
+                    % self.criterion)
+            std = _return_std(X, self.estimators_, mean, self.min_variance)
+            return mean, std
+
+        return mean

--- a/skgarden/gbrt.py
+++ b/skgarden/gbrt.py
@@ -1,0 +1,119 @@
+import numpy as np
+
+from sklearn.base import clone
+from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.utils import check_random_state
+from sklearn.externals.joblib import Parallel, delayed
+
+
+def _parallel_fit(regressor, X, y):
+    return regressor.fit(X, y)
+
+
+class GradientBoostingQuantileRegressor(BaseEstimator, RegressorMixin):
+    """Predict several quantiles with one estimator.
+
+    This is a wrapper around `GradientBoostingRegressor`'s quantile
+    regression that allows you to predict several `quantiles` in
+    one go.
+
+    Parameters
+    ----------
+    * `quantiles` [array-like]:
+        Quantiles to predict. By default the 16, 50 and 84%
+        quantiles are predicted.
+
+    * `base_estimator` [GradientBoostingRegressor instance or None (default)]:
+        Quantile regressor used to make predictions. Only instances
+        of `GradientBoostingRegressor` are supported. Use this to change
+        the hyper-parameters of the estimator.
+
+    * `n_jobs` [int, default=1]:
+        The number of jobs to run in parallel for `fit`.
+        If -1, then the number of jobs is set to the number of cores.
+
+    * `random_state` [int, RandomState instance, or None (default)]:
+        Set random state to something other than None for reproducible
+        results.
+    """
+
+    def __init__(self, quantiles=[0.16, 0.5, 0.84], base_estimator=None,
+                 n_jobs=1, random_state=None):
+        self.quantiles = quantiles
+        self.random_state = random_state
+        self.base_estimator = base_estimator
+        self.n_jobs = n_jobs
+
+    def fit(self, X, y):
+        """Fit one regressor for each quantile.
+
+        Parameters
+        ----------
+        * `X` [array-like, shape=(n_samples, n_features)]:
+            Training vectors, where `n_samples` is the number of samples
+            and `n_features` is the number of features.
+
+        * `y` [array-like, shape=(n_samples,)]:
+            Target values (real numbers in regression)
+        """
+        rng = check_random_state(self.random_state)
+
+        if self.base_estimator is None:
+            base_estimator = GradientBoostingRegressor(loss='quantile')
+        else:
+            base_estimator = self.base_estimator
+
+            if not isinstance(base_estimator, GradientBoostingRegressor):
+                raise ValueError('base_estimator has to be of type'
+                                 ' GradientBoostingRegressor.')
+
+            if not base_estimator.loss == 'quantile':
+                raise ValueError('base_estimator has to use quantile'
+                                 ' loss not %s' % base_estimator.loss)
+
+        # The predictions for different quantiles should be sorted.
+        # Therefore each of the regressors need the same seed.
+        base_estimator.set_params(random_state=rng)
+        regressors = []
+        for q in self.quantiles:
+            regressor = clone(base_estimator)
+            regressor.set_params(alpha=q)
+
+            regressors.append(regressor)
+
+        self.regressors_ = Parallel(n_jobs=self.n_jobs, backend='threading')(
+            delayed(_parallel_fit)(regressor, X, y)
+            for regressor in regressors)
+
+        return self
+
+    def predict(self, X, return_std=False):
+        """Predict.
+
+        Predict `X` at every quantile if `return_std` is set to False.
+        If `return_std` is set to True, then return the mean
+        and the predicted standard deviation, which is approximated as
+        the (0.84th quantile - 0.16th quantile) divided by 2.0
+
+        Parameters
+        ----------
+        * `X` [array-like, shape=(n_samples, n_features)]:
+            where `n_samples` is the number of samples
+            and `n_features` is the number of features.
+        """
+        predicted_quantiles = np.asarray(
+            [rgr.predict(X) for rgr in self.regressors_])
+        if not return_std:
+            return predicted_quantiles.T
+        else:
+            std_quantiles = [0.16, 0.5, 0.84]
+            is_present_mask = np.in1d(std_quantiles, self.quantiles)
+            if not np.all(is_present_mask):
+                raise ValueError(
+                    "return_std works only if the quantiles during "
+                    "instantiation include 0.16, 0.5 and 0.84")
+            low = self.regressors_[self.quantiles.index(0.16)].predict(X)
+            high = self.regressors_[self.quantiles.index(0.84)].predict(X)
+            mean = self.regressors_[self.quantiles.index(0.5)].predict(X)
+            return mean, ((high - low) / 2.0)

--- a/skgarden/mondrian/ensemble/forest.py
+++ b/skgarden/mondrian/ensemble/forest.py
@@ -7,6 +7,7 @@ from sklearn.utils.validation import check_X_y
 
 from ..tree import MondrianTreeRegressor
 
+
 class MondrianForestRegressor(ForestRegressor):
     """
     A MondrianForestRegressor is an ensemble of MondrianTrees.
@@ -65,8 +66,8 @@ class MondrianForestRegressor(ForestRegressor):
         Parameters
         ----------
         X : array-like or sparse matrix of shape = [n_samples, n_features]
-            The training input samples. Internally, its dtype will be converted to
-            ``dtype=np.float32``. If a sparse matrix is provided, it will be
+            The training input samples. Internally, its dtype will be converted
+            to ``dtype=np.float32``. If a sparse matrix is provided, it will be
             converted into a sparse ``csc_matrix``.
         y : array-like, shape = [n_samples] or [n_samples, n_outputs]
             The target values (class labels in classification, real numbers in

--- a/skgarden/mondrian/ensemble/tests/test_forest.py
+++ b/skgarden/mondrian/ensemble/tests/test_forest.py
@@ -5,7 +5,6 @@ import numpy as np
 from sklearn.datasets import load_boston
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import MinMaxScaler
-from sklearn.utils import check_random_state
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
@@ -21,6 +20,7 @@ boston = load_boston()
 scaler = MinMaxScaler()
 X, y = boston.data, boston.target
 X = scaler.fit_transform(X)
+
 
 def test_boston():
     mr = MondrianForestRegressor(n_estimators=5, random_state=0)
@@ -53,9 +53,9 @@ def test_pickle():
 
 def test_parallel_train():
     mr = MondrianForestRegressor(n_estimators=20, random_state=0, max_depth=4)
-    y_pred = (
-        [mr.set_params(n_jobs=n_jobs).fit(X, y).predict(X) for n_jobs in [1, 2, 4, 8]]
-    )
+    y_pred = ([mr.set_params(n_jobs=n_jobs).fit(X, y).predict(X)
+               for n_jobs in [1, 2, 4, 8]])
+
     for pred1, pred2 in zip(y_pred, y_pred[1:]):
         assert_array_equal(pred1, pred2)
 
@@ -101,7 +101,7 @@ def test_decision_path():
     mr = MondrianForestRegressor(random_state=0)
     mr.fit(X, y)
     indicator, col_inds = mr.decision_path(X)
-    indices, indptr, data = indicator.indices, indicator.indptr, indicator.data
+    indices, indptr = indicator.indices, indicator.indptr
 
     n_nodes = [est.tree_.node_count for est in mr.estimators_]
     assert_equal(indicator.shape[0], X.shape[0])
@@ -143,6 +143,7 @@ def test_weighted_decision_path():
     assert_array_almost_equal(
         np.ravel(mr.weighted_decision_path(X_test)[0].sum(axis=1)),
         mr.n_estimators * np.ones(X_test.shape[0]), 5)
+
 
 def test_mean_std():
     mr = MondrianForestRegressor(random_state=0)

--- a/skgarden/mondrian/tree/tests/test_mondrian_regressor.py
+++ b/skgarden/mondrian/tree/tests/test_mondrian_regressor.py
@@ -4,10 +4,8 @@ from sklearn.datasets import load_iris
 from sklearn.datasets import make_regression
 from sklearn.metrics import mean_squared_error
 from sklearn.preprocessing import MinMaxScaler
-from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_array_less
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_false

--- a/skgarden/tests/test_forest.py
+++ b/skgarden/tests/test_forest.py
@@ -1,0 +1,68 @@
+import numpy as np
+from functools import partial
+
+from sklearn.utils import check_random_state
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
+
+from skgarden import RandomForestRegressor
+from skgarden import ExtraTreesRegressor
+
+
+def check_variance_toy_data(Regressor):
+    # Split into [2, 3, 4] and [100, 103, 106]
+    X = [[2.0, 1.], [3.0, 1.0], [4., 1.0],
+         [109.0, 1.0], [110.0, 1.0], [111., 1.]]
+    y = [2, 3, 4, 100, 103, 106]
+
+    reg = Regressor(max_depth=1, random_state=1)
+    reg.fit(X, y)
+
+    pred, var = reg.predict(X, return_std=True)
+    assert_array_equal(pred, [3, 3, 3, 103, 103, 103])
+    assert_array_almost_equal(
+        var, np.sqrt([0.666667, 0.666667, 0.666667, 6.0, 6.0, 6.0]))
+
+
+def test_variance_toy_data():
+    """Test that `return_std` behaves expected on toy data."""
+    for Regressor in [partial(RandomForestRegressor, bootstrap=False),
+                      ExtraTreesRegressor]:
+        yield check_variance_toy_data, Regressor
+
+
+def check_variance_no_split(Regressor):
+    rng = check_random_state(0)
+    X = np.ones((1000, 1))
+    y = rng.normal(size=(1000,))
+
+    reg = Regressor(random_state=0, max_depth=3)
+    reg.fit(X, y)
+
+    pred, std = reg.predict(X, return_std=True)
+    assert_array_almost_equal([np.std(y)] * 1000, std)
+    assert_array_almost_equal([np.mean(y)] * 1000, pred)
+
+
+def test_variance_no_split():
+    """
+    Test that `return_std` behaves expected on a tree with one node.
+
+    The decision tree should not produce a split, because there is
+    no information gain which enables us to verify the mean and
+    standard deviation.
+    """
+    for Regressor in [partial(RandomForestRegressor, bootstrap=False),
+                      ExtraTreesRegressor]:
+        yield check_variance_no_split, Regressor
+
+
+def test_min_variance():
+    rng = check_random_state(0)
+    X = rng.normal(size=(1000, 1))
+    y = np.ones(1000)
+    rf = RandomForestRegressor(min_variance=0.1)
+    rf.fit(X, y)
+    mean, std = rf.predict(X, return_std=True)
+    assert_array_almost_equal(mean, y)
+    assert_array_almost_equal(std, np.sqrt(0.1*np.ones(1000)))

--- a/skgarden/tests/test_gbrt.py
+++ b/skgarden/tests/test_gbrt.py
@@ -1,0 +1,100 @@
+import numpy as np
+from scipy import stats
+
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.ensemble import RandomForestRegressor
+
+from sklearn.utils import check_random_state
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_raise_message
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_almost_equal
+
+from skgarden import GradientBoostingQuantileRegressor
+
+
+def truth(X):
+    return 0.5 * np.sin(1.75*X[:, 0])
+
+
+def test_gbrt_gaussian():
+    # estimate quantiles of the normal distribution
+    rng = check_random_state(1)
+    N = 10000
+    X = np.ones((N, 1))
+    y = rng.normal(size=N)
+
+    rgr = GradientBoostingQuantileRegressor()
+    rgr.fit(X, y)
+
+    estimates = rgr.predict(X)
+    assert_almost_equal(stats.norm.ppf(rgr.quantiles),
+                        np.mean(estimates, axis=0),
+                        decimal=2)
+
+
+def test_gbrt_base_estimator():
+    rng = check_random_state(1)
+    N = 10000
+    X = np.ones((N, 1))
+    y = rng.normal(size=N)
+
+    base = RandomForestRegressor()
+    rgr = GradientBoostingQuantileRegressor(base_estimator=base)
+    assert_raise_message(ValueError, 'type GradientBoostingRegressor',
+                         rgr.fit, X, y)
+
+    base = GradientBoostingRegressor()
+    rgr = GradientBoostingQuantileRegressor(base_estimator=base)
+    assert_raise_message(ValueError, 'quantile loss', rgr.fit, X, y)
+
+    base = GradientBoostingRegressor(loss='quantile', n_estimators=20)
+    rgr = GradientBoostingQuantileRegressor(base_estimator=base)
+    rgr.fit(X, y)
+
+    estimates = rgr.predict(X)
+    assert_almost_equal(stats.norm.ppf(rgr.quantiles),
+                        np.mean(estimates, axis=0),
+                        decimal=2)
+
+
+def test_gbrt_with_std():
+    # simple test of the interface
+    rng = check_random_state(1)
+    X = rng.uniform(0, 5, 500)[:, np.newaxis]
+
+    noise_level = 0.5
+    y = truth(X) + rng.normal(0, noise_level, len(X))
+    X_ = np.linspace(0, 5, 1000)[:, np.newaxis]
+
+    model = GradientBoostingQuantileRegressor()
+    model.fit(X, y)
+
+    assert_array_equal(model.predict(X_).shape, (len(X_), 3))
+
+    l, c, h = model.predict(X_).T
+    assert_equal(l.shape, c.shape, h.shape)
+    assert_equal(l.shape[0], X_.shape[0])
+
+    mean, std = model.predict(X_, return_std=True)
+    assert_array_equal(mean, c)
+    assert_array_equal(std, (h - l) / 2.0)
+
+
+def test_gbrt_in_parallel():
+    # check estimate quantiles with parallel
+    rng = check_random_state(1)
+    N = 10000
+    X = np.ones((N, 1))
+    y = rng.normal(size=N)
+
+    rgr = GradientBoostingQuantileRegressor(
+        n_jobs=1, random_state=np.random.RandomState(1))
+    rgr.fit(X, y)
+    estimates = rgr.predict(X)
+
+    rgr.set_params(n_jobs=2, random_state=np.random.RandomState(1))
+    rgr.fit(X, y)
+    estimates_parallel = rgr.predict(X)
+
+    assert_array_equal(estimates, estimates_parallel)


### PR DESCRIPTION
Mostly copy/pasted from `skopt.learning`. Some small cosmits along the way.

Fix for #5. 