### PR TITLE
Remove mean field from Node

### DIFF
--- a/skgarden/mondrian/tree/_tree.pxd
+++ b/skgarden/mondrian/tree/_tree.pxd
@@ -66,7 +66,7 @@ cdef class Tree:
                           double weighted_n_samples,
                           DTYPE_t* lower_bounds,
                           DTYPE_t* upper_bounds,
-                          double E, DOUBLE_t mean) nogil except -1
+                          double E) nogil except -1
     cdef int _resize(self, SIZE_t capacity) nogil except -1
     cdef int _resize_c(self, SIZE_t capacity=*) nogil except -1
 


### PR DESCRIPTION
This removes storing the mean at every node, since the values are accessible from the `values` array of the tree.

The larger reason is to have a unified `_add_node` interface between regression and classification. Removing the `DOUBLE_t mean` argument makes it easier to do so. 