### PR TITLE
Remove min_impurity_split

### DIFF
--- a/skgarden/mondrian/ensemble/tests/test_forest.py
+++ b/skgarden/mondrian/ensemble/tests/test_forest.py
@@ -158,8 +158,8 @@ def test_mean_std():
     # For points completely far away from the training data, this
     # should converge to the empirical mean and variance.
     # X is scaled between to -1.0 and 1.0
-    X_inf = np.vstack((20.0 * np.ones(X.shape[1]),
-                       -20.0 * np.ones(X.shape[1])))
+    X_inf = np.vstack((30.0 * np.ones(X.shape[1]),
+                       -30.0 * np.ones(X.shape[1])))
     inf_mean, inf_std = mr.predict(X_inf, return_std=True)
     assert_array_almost_equal(inf_mean, y.mean(), 1)
     assert_array_almost_equal(inf_std, y.std(), 2)

--- a/skgarden/mondrian/tree/_tree.pxd
+++ b/skgarden/mondrian/tree/_tree.pxd
@@ -105,7 +105,6 @@ cdef class TreeBuilder:
     cdef SIZE_t min_samples_leaf    # Minimum number of samples in a leaf
     cdef double min_weight_leaf     # Minimum weight in a leaf
     cdef SIZE_t max_depth           # Maximal tree depth
-    cdef double min_impurity_split  # Impurity threshold for early stopping
 
     cpdef build(self, Tree tree, object X, np.ndarray y,
                 np.ndarray sample_weight=*,

--- a/skgarden/mondrian/tree/_tree.pyx
+++ b/skgarden/mondrian/tree/_tree.pyx
@@ -136,13 +136,12 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
 
     def __cinit__(self, Splitter splitter, SIZE_t min_samples_split,
                   SIZE_t min_samples_leaf, double min_weight_leaf,
-                  SIZE_t max_depth, double min_impurity_split):
+                  SIZE_t max_depth):
         self.splitter = splitter
         self.min_samples_split = min_samples_split
         self.min_samples_leaf = min_samples_leaf
         self.min_weight_leaf = min_weight_leaf
         self.max_depth = max_depth
-        self.min_impurity_split = min_impurity_split
 
     cpdef build(self, Tree tree, object X, np.ndarray y,
                 np.ndarray sample_weight=None,
@@ -172,7 +171,6 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
         cdef SIZE_t min_samples_leaf = self.min_samples_leaf
         cdef double min_weight_leaf = self.min_weight_leaf
         cdef SIZE_t min_samples_split = self.min_samples_split
-        cdef double min_impurity_split = self.min_impurity_split
 
         # Recursive partition (without actual recursion)
         splitter.init(X, y, sample_weight_ptr, X_idx_sorted)
@@ -229,9 +227,6 @@ cdef class DepthFirstTreeBuilder(TreeBuilder):
                 if first:
                     impurity = splitter.node_impurity()
                     first = 0
-
-                is_leaf = (is_leaf or
-                           (impurity <= min_impurity_split))
 
                 if not is_leaf:
                     is_leaf = splitter.node_split(impurity, &split, &n_constant_features)

--- a/skgarden/mondrian/tree/tree.py
+++ b/skgarden/mondrian/tree/tree.py
@@ -58,7 +58,7 @@ DOUBLE = _tree.DOUBLE
 
 CRITERIA_REG = {"mse": _criterion.MSE}
 
-DENSE_SPLITTERS = {"mondrian": _splitter.MondrianSplitter}
+SPLITTERS = {"mondrian": _splitter.MondrianSplitter}
 
 # =============================================================================
 # Base decision tree
@@ -83,7 +83,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
                  max_features,
                  max_leaf_nodes,
                  random_state,
-                 min_impurity_split,
                  class_weight=None,
                  presort=False):
         self.criterion = criterion
@@ -95,7 +94,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         self.max_features = max_features
         self.random_state = random_state
         self.max_leaf_nodes = max_leaf_nodes
-        self.min_impurity_split = min_impurity_split
         self.class_weight = class_weight
         self.presort = presort
 
@@ -259,10 +257,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
             min_weight_leaf = (self.min_weight_fraction_leaf *
                                np.sum(sample_weight))
 
-        if self.min_impurity_split < 0.:
-            raise ValueError("min_impurity_split must be greater than "
-                             "or equal to 0")
-
         presort = self.presort
         # Allow presort to be 'auto', which means True if the dataset is dense,
         # otherwise it will be False.
@@ -300,8 +294,6 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
                 criterion = CRITERIA_REG[self.criterion](self.n_outputs_,
                                                          n_samples)
 
-        SPLITTERS = SPARSE_SPLITTERS if issparse(X) else DENSE_SPLITTERS
-
         splitter = self.splitter
         if not isinstance(self.splitter, Splitter):
             splitter = SPLITTERS[self.splitter](criterion,
@@ -317,7 +309,7 @@ class BaseDecisionTree(six.with_metaclass(ABCMeta, BaseEstimator)):
         builder = DepthFirstTreeBuilder(splitter, min_samples_split,
                                         min_samples_leaf,
                                         min_weight_leaf,
-                                        max_depth, self.min_impurity_split)
+                                        max_depth)
         builder.build(self.tree_, X, y, sample_weight, X_idx_sorted)
 
         if self.n_outputs_ == 1:
@@ -528,7 +520,6 @@ class MondrianTreeRegressor(BaseDecisionTree, RegressorMixin):
             max_features=None,
             random_state=random_state,
             max_leaf_nodes=None,
-            min_impurity_split=1e-7,
             presort=False)
 
     def fit(self, X, y, sample_weight=None, check_input=True, X_idx_sorted=None):


### PR DESCRIPTION
`min_impurity_split` was removed since https://github.com/scikit-learn/scikit-learn/pull/8449.

Whether we want to keep other hyper-parameters through `BaseDecisionTree` is debatable but this has to be removed.