### PR TITLE
Remove children impurity calculation

### DIFF
--- a/skgarden/mondrian/tree/_splitter.pyx
+++ b/skgarden/mondrian/tree/_splitter.pyx
@@ -437,9 +437,5 @@ cdef class MondrianSplitter(BaseDenseSplitter):
                 samples[p] = tmp
 
         split.pos = p
-        self.criterion.reset()
-        self.criterion.update(split.pos)
-        self.criterion.children_impurity(&split.impurity_left,
-                                         &split.impurity_right)
         free(cum_diff)
         return 0


### PR DESCRIPTION
The criterion is initialized at every call to `node_reset` which is sufficient to calculate the statistics of every node. This removes the impurity calculation of the left and right children which is unnecessary for a MondrainSplitter.