### PR TITLE
include LICENSE.txt in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include MANIFEST.in
+include LICENSE.txt
 recursive-include skgarden *.pyx *.pxd

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+license-file = LICENSE.txt


### PR DESCRIPTION
The New BSD license you're using requires the license file to be included in redistributions of the code, but currently the .tar.gz files on pypi don't include it. The `MANIFEST.in` change will include the license file in `sdist`s, and the `setup.cfg` change puts it in wheels.