### PR TITLE
Update ensemble.py

### DIFF
--- a/skgarden/quantile/ensemble.py
+++ b/skgarden/quantile/ensemble.py
@@ -131,7 +131,6 @@ class BaseForestQuantileRegressor(ForestRegressor):
 
         sorter = np.argsort(self.y_train_)
         X_leaves = self.apply(X)
-        weights = np.zeros((X.shape[0], len(self.y_train_)))
         quantiles = np.zeros((X.shape[0]))
         for i, x_leaf in enumerate(X_leaves):
             mask = self.y_train_leaves_ != np.expand_dims(x_leaf, 1)


### PR DESCRIPTION
https://github.com/scikit-garden/scikit-garden/blob/23c5139674137f694fc959ed10979abd9d6058fa/skgarden/quantile/ensemble.py#L134

This line is unnecessary because it gets overwritten by https://github.com/scikit-garden/scikit-garden/blob/23c5139674137f694fc959ed10979abd9d6058fa/skgarden/quantile/ensemble.py#L139

It's existence is causing a memory overflow on large datasets. For instance, take a dataset that has 1 million datapoints. The default dtype for np.zeros is int64, so the total size of the array becomes 1,000,000*1,000,000*64 = **64 terabytes**. Even at a more reasonable 50k datapoints, that line will still produce a 160 GB array, which is unreasonable on any modern system. 