### PR TITLE
Make scikit-garden work with scikit-learn 0.23

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ URL = 'https://github.com/scikit-garden/scikit-garden'
 MAINTAINER = 'Manoj Kumar'
 MAINTAINER_EMAIL = 'mks542@nyu.edu'
 LICENSE = 'new BSD'
-VERSION = '0.1.3'
+VERSION = '0.1.4'
 
 CYTHON_MIN_VERSION = '0.23'
 

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,6 @@ if __name__ == "__main__":
               'Operating System :: Unix',
               'Operating System :: MacOS'
             ],
-          install_requires=["numpy", "scipy", "scikit-learn>=0.18", "cython"],
+          install_requires=["numpy", "scipy", "scikit-learn>=0.18", "cython", "joblib", "six"],
           setup_requires=["cython"],
           ext_modules=extensions)

--- a/skgarden/mondrian/ensemble/forest.py
+++ b/skgarden/mondrian/ensemble/forest.py
@@ -3,8 +3,8 @@ from scipy import sparse
 from sklearn.base import ClassifierMixin
 from sklearn.ensemble.forest import ForestClassifier
 from sklearn.ensemble.forest import ForestRegressor
-from sklearn.exceptions import NotFittedError
-from sklearn.externals.joblib import delayed, Parallel
+from sklearn.exceptions import NotFittedError, DataConversionWarning
+from joblib import delayed, Parallel
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import check_array

--- a/skgarden/mondrian/ensemble/forest.py
+++ b/skgarden/mondrian/ensemble/forest.py
@@ -116,10 +116,10 @@ class BaseMondrian(object):
 
         # XXX: Switch to threading backend when GIL is released.
         if isinstance(self, ClassifierMixin):
-            self.estimators_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
+            self.estimators_ = Parallel(n_jobs=self.n_jobs, backend="multiprocessing", verbose=self.verbose)(
                 delayed(_single_tree_pfit)(t, X, y, classes) for t in self.estimators_)
         else:
-            self.estimators_ = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
+            self.estimators_ = Parallel(n_jobs=self.n_jobs, backend="multiprocessing", verbose=self.verbose)(
                 delayed(_single_tree_pfit)(t, X, y) for t in self.estimators_)
 
         return self

--- a/skgarden/mondrian/ensemble/tests/test_forest.py
+++ b/skgarden/mondrian/ensemble/tests/test_forest.py
@@ -9,12 +9,12 @@ from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import LabelEncoder
 from sklearn.preprocessing import MinMaxScaler
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_false
-from sklearn.utils.testing import assert_true
-from sklearn.utils.testing import assert_greater
+from skgarden.utils.testing import assert_array_equal
+from skgarden.utils.testing import assert_array_almost_equal
+from skgarden.utils.testing import assert_equal
+from skgarden.utils.testing import assert_false
+from skgarden.utils.testing import assert_true
+from skgarden.utils.testing import assert_greater
 
 from skgarden import MondrianForestClassifier
 from skgarden import MondrianForestRegressor

--- a/skgarden/mondrian/ensemble/tests/test_forest_partial_fit.py
+++ b/skgarden/mondrian/ensemble/tests/test_forest_partial_fit.py
@@ -2,9 +2,9 @@ import numpy as np
 from sklearn.datasets import load_digits
 from sklearn.datasets import make_classification
 from sklearn.datasets import make_regression
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_greater
+from skgarden.utils.testing import assert_array_equal
+from skgarden.utils.testing import assert_equal
+from skgarden.utils.testing import assert_greater
 
 from skgarden import MondrianForestRegressor
 from skgarden import MondrianForestClassifier

--- a/skgarden/mondrian/tree/tests/test_mondrian.py
+++ b/skgarden/mondrian/tree/tests/test_mondrian.py
@@ -16,14 +16,13 @@ from sklearn.metrics import mean_squared_error
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.preprocessing import LabelEncoder
 from sklearn.preprocessing import MinMaxScaler
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_false
-from sklearn.utils.testing import assert_greater
-from sklearn.utils.testing import assert_less
-from sklearn.utils.testing import assert_true
+from skgarden.utils.testing import assert_array_equal
+from skgarden.utils.testing import assert_array_almost_equal
+from skgarden.utils.testing import assert_almost_equal
+from skgarden.utils.testing import assert_equal
+from skgarden.utils.testing import assert_false
+from skgarden.utils.testing import assert_less
+from skgarden.utils.testing import assert_true
 
 from skgarden.mondrian import MondrianTreeClassifier
 from skgarden.mondrian import MondrianTreeRegressor
@@ -354,7 +353,7 @@ def test_weighted_decision_path_classif():
 
 def test_std_positive():
     """Sometimes variance can be slightly negative due to numerical errors."""
-    X = np.linspace(-np.pi, np.pi, 20.0)
+    X = np.linspace(-np.pi, np.pi, 20)
     y = 2*np.sin(X)
     X_train = np.reshape(X, (-1, 1))
     mr = MondrianTreeRegressor(random_state=0)

--- a/skgarden/mondrian/tree/tests/test_mondrian_partial_fit.py
+++ b/skgarden/mondrian/tree/tests/test_mondrian_partial_fit.py
@@ -7,10 +7,10 @@ from sklearn.datasets import make_classification
 from sklearn.datasets import make_regression
 from sklearn.datasets import load_digits
 from sklearn.utils.testing import assert_almost_equal
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_greater
+from skgarden.utils.testing import assert_equal
+from skgarden.utils.testing import assert_array_almost_equal
+from skgarden.utils.testing import assert_array_equal
+from skgarden.utils.testing import assert_greater
 
 from skgarden import MondrianTreeClassifier
 from skgarden import MondrianTreeRegressor

--- a/skgarden/mondrian/tree/tree.py
+++ b/skgarden/mondrian/tree/tree.py
@@ -28,7 +28,7 @@ from scipy.sparse import issparse
 from sklearn.base import BaseEstimator
 from sklearn.base import ClassifierMixin
 from sklearn.base import RegressorMixin
-from sklearn.externals import six
+import six
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_random_state
 from sklearn.utils import compute_sample_weight

--- a/skgarden/quantile/tests/test_ensemble.py
+++ b/skgarden/quantile/tests/test_ensemble.py
@@ -2,9 +2,9 @@ import numpy as np
 from sklearn.datasets import load_boston
 from sklearn.model_selection import train_test_split
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_true
+from skgarden.utils.testing import assert_array_equal
+from skgarden.utils.testing import assert_array_almost_equal
+from skgarden.utils.testing import assert_true
 
 from skgarden.quantile import RandomForestQuantileRegressor
 from skgarden.quantile import ExtraTreesQuantileRegressor
@@ -72,7 +72,7 @@ def test_max_depth_None_rfqr():
     # the mean equals any quantile.
     rng = np.random.RandomState(0)
     X = rng.randn(10, 1)
-    y = np.linspace(0.0, 100.0, 10.0)
+    y = np.linspace(0.0, 100.0, 10)
 
     rfqr = RandomForestQuantileRegressor(
         random_state=0, bootstrap=False, max_depth=None)
@@ -90,7 +90,7 @@ def test_base_forest_quantile():
     """
     rng = np.random.RandomState(0)
     X = rng.randn(10, 1)
-    y = np.linspace(0.0, 100.0, 10.0)
+    y = np.linspace(0.0, 100.0, 10)
 
     rfqr = RandomForestQuantileRegressor(random_state=0, max_depth=1)
     rfqr.fit(X, y)

--- a/skgarden/quantile/tests/test_tree.py
+++ b/skgarden/quantile/tests/test_tree.py
@@ -1,7 +1,7 @@
 import numpy as np
 from sklearn.datasets import load_boston
 from sklearn.model_selection import train_test_split
-from sklearn.utils.testing import assert_array_almost_equal
+from skgarden.utils.testing import assert_array_almost_equal
 
 from skgarden.quantile import DecisionTreeQuantileRegressor
 from skgarden.quantile import ExtraTreeQuantileRegressor

--- a/skgarden/quantile/tests/test_utils.py
+++ b/skgarden/quantile/tests/test_utils.py
@@ -1,9 +1,9 @@
 import numpy as np
 from skgarden.quantile.utils import weighted_percentile
 
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_almost_equal
+from skgarden.utils.testing import assert_equal
+from skgarden.utils.testing import assert_array_almost_equal
+from skgarden.utils.testing import assert_almost_equal
 
 def test_percentile_equal_weights():
     rng = np.random.RandomState(0)

--- a/skgarden/quantile/tree.py
+++ b/skgarden/quantile/tree.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from sklearn.tree.tree import BaseDecisionTree
+from sklearn.tree import BaseDecisionTree
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.tree import ExtraTreeRegressor
 from sklearn.utils import check_array

--- a/skgarden/quantile/tree.py
+++ b/skgarden/quantile/tree.py
@@ -173,12 +173,6 @@ class DecisionTreeQuantileRegressor(DecisionTreeRegressor, BaseTreeQuantileRegre
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    presort : bool, optional (default=False)
-        Whether to presort the data to speed up the finding of best splits in
-        fitting. For the default settings of a decision tree on large
-        datasets, setting this to true may slow down the training process.
-        When using either a smaller dataset or a restricted depth, this may
-        speed up the training.
 
     Attributes
     ----------
@@ -217,8 +211,7 @@ class DecisionTreeQuantileRegressor(DecisionTreeRegressor, BaseTreeQuantileRegre
                  min_weight_fraction_leaf=0.,
                  max_features=None,
                  random_state=None,
-                 max_leaf_nodes=None,
-                 presort=False):
+                 max_leaf_nodes=None):
         super(DecisionTreeQuantileRegressor, self).__init__(
             criterion=criterion,
             splitter=splitter,
@@ -228,8 +221,7 @@ class DecisionTreeQuantileRegressor(DecisionTreeRegressor, BaseTreeQuantileRegre
             min_weight_fraction_leaf=min_weight_fraction_leaf,
             max_features=max_features,
             max_leaf_nodes=max_leaf_nodes,
-            random_state=random_state,
-            presort=presort)
+            random_state=random_state)
 
 
 class ExtraTreeQuantileRegressor(ExtraTreeRegressor, BaseTreeQuantileRegressor):

--- a/skgarden/tests/test_forest.py
+++ b/skgarden/tests/test_forest.py
@@ -2,8 +2,8 @@ import numpy as np
 from functools import partial
 
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_array_almost_equal
+from skgarden.utils.testing import assert_array_equal
+from skgarden.utils.testing import assert_array_almost_equal
 
 from skgarden import RandomForestRegressor
 from skgarden import ExtraTreesRegressor

--- a/skgarden/utils/testing.py
+++ b/skgarden/utils/testing.py
@@ -1,0 +1,41 @@
+"""
+This module contains assertion function removed in scikit-learn 0.23
+"""
+
+# Authors: Florian Seidel (seidel.florian@gmail.com)
+#
+# License: BSD 3 clause
+
+import unittest
+from unittest import TestCase
+
+from numpy.testing import assert_allclose
+from numpy.testing import assert_almost_equal
+from numpy.testing import assert_approx_equal
+from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_less
+
+
+__all__ = ["assert_equal", "assert_not_equal", "assert_raises",
+           "assert_almost_equal", "assert_array_equal",
+           "assert_array_almost_equal", "assert_array_less",
+           "assert_less", "assert_less_equal",
+           "assert_greater", "assert_greater_equal",
+           "assert_approx_equal", "assert_allclose",
+           "SkipTest", "assert_false", "assert_true"]
+
+_dummy = TestCase('__init__')
+assert_true = _dummy.assertTrue
+assert_false = _dummy.assertFalse
+assert_equal = _dummy.assertEqual
+assert_not_equal = _dummy.assertNotEqual
+assert_raises = _dummy.assertRaises
+SkipTest = unittest.case.SkipTest
+assert_dict_equal = _dummy.assertDictEqual
+assert_in = _dummy.assertIn
+assert_not_in = _dummy.assertNotIn
+assert_less = _dummy.assertLess
+assert_greater = _dummy.assertGreater
+assert_less_equal = _dummy.assertLessEqual
+assert_greater_equal = _dummy.assertGreaterEqual


### PR DESCRIPTION
I wanted to use scikit-garden with scikit-learn 0.23. Didn't work, so I made an attempt at fixing the problems introduced by the newer scikit version.

It was mainly the imports, but also a few problems in the unit tests. 
For me the loky joblib backend doesn't work, so I replaced it with multiprocessing.

Hope we can make this work.