### PR TITLE
Cython >= 3.0 throws a compile error. Downgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,6 @@ if __name__ == "__main__":
               'Operating System :: MacOS'
             ],
           install_requires=["numpy", "scipy", "scikit-learn>=0.22", "six"],
-          setup_requires=["Cython>=0.23", "numpy", "setuptools>=18"],
+          setup_requires=["Cython>=0.23,<3.0", "numpy", "setuptools>=18"],
           ext_modules=extensions,
           )


### PR DESCRIPTION
Fixes #111